### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through the GitHub Certifications program",
+        "schedule": "Tuesdays and Thursdays, 4:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Resolves #6

### Summary
Adds the GitHub Skills activity that was announced by the principal to the extracurricular activities list.

### Changes Made
- Added "GitHub Skills" activity to the activities dictionary
- Includes reference to the GitHub Certifications program
- Scheduled for Tuesdays and Thursdays, 4:30 PM - 5:30 PM
- Set maximum capacity to 25 participants

### Context
Students were eager to register for this program to help with college applications, but it wasn't available on the website. This PR makes it available for registration immediately.

### Testing
The activity will now appear in the activities list and students can sign up through the existing registration form.